### PR TITLE
Run the build on later versions of Node.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [16, 17]
+        node-version: [16, 17, 18, 19]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I believe the main version on Netlify right now is still 16. https://github.com/netlify/build-image/blob/focal/included_software.md

But it doesn't hurt to run on later versions, so we know we will be OK.
